### PR TITLE
Adapt the script to work with receiver-type=beast-tcp

### DIFF
--- a/PI24_replace_dump1090_v1.14_by_v1.15.sh
+++ b/PI24_replace_dump1090_v1.14_by_v1.15.sh
@@ -3,26 +3,35 @@
 if ! [ -f  /usr/lib/fr24/install_dump1090.sh ]; then echo "fr24feed not installed, install fr24feed before using this script!"; exit 1; fi
 
 #Fix PI24 image's "readonly file system".
-sudo mount -o remount,rw /
+mount -o remount,rw /
+sed -i -e 's?$(mount | grep " on / " | grep rw)?{ mount | grep " on / " | grep rw; }?' /usr/lib/fr24/fr24feed_updater.sh &>/dev/null
 
-sudo sed -i 's/.*1.14/#&/' /usr/lib/fr24/install_dump1090.sh
+systemctl stop fr24feed
 
-sudo sed -i '/wget -O \/tmp\/dump1090-mutability_1.14_armhf.deb/i\    wget -O \/tmp\/dump1090-mutability_1.15_dev_armhf.deb https:\/\/github.com\/abcd567a\/dump1090\/releases\/download\/v1\/dump1090-mutability_1.15_dev_armhf.deb\n    dpkg -i \/tmp/dump1090-mutability_1.15_dev_armhf.deb\n    rm -f /tmp/dump1090-mutability_1.15_dev_armhf.deb\n' /usr/lib/fr24/install_dump1090.sh
+sed -i 's/.*1.14/#&/' /usr/lib/fr24/install_dump1090.sh
 
-sudo dpkg --purge dump1090-mutability
+sed -i '/wget -O \/tmp\/dump1090-mutability_1.14_armhf.deb/i\    wget -O \/tmp\/dump1090-mutability_1.15_dev_armhf.deb https:\/\/github.com\/abcd567a\/dump1090\/releases\/download\/v1\/dump1090-mutability_1.15_dev_armhf.deb\n    dpkg -i \/tmp/dump1090-mutability_1.15_dev_armhf.deb\n    rm -f /tmp/dump1090-mutability_1.15_dev_armhf.deb\n' /usr/lib/fr24/install_dump1090.sh
 
-cd /usr/lib/fr24/
+# different install methods depending on receiver-type
+if grep -q "^receiver.*dvbt" /etc/fr24feed.ini
+then
+	rm -f /usr/lib/fr24/dump1090
+	/usr/lib/fr24/install_dump1090.sh
+else
+	wget -O /tmp/dump1090-mutability_1.15_dev_armhf.deb https://github.com/abcd567a/dump1090/releases/download/v1/dump1090-mutability_1.15_dev_armhf.deb
+	dpkg -i /tmp/dump1090-mutability_1.15_dev_armhf.deb
+	rm -f /tmp/dump1090-mutability_1.15_dev_armhf.deb
+fi
 
-sudo ./install_dump1090.sh
 
-sudo service lighttpd force-reload
+service lighttpd force-reload
 
-sudo systemctl restart fr24feed
+systemctl restart fr24feed
 
 echo "---------------"
 echo "ALL DONE !"
 echo "---------------"
-echo "Go to your broweser and check map on following address"
+echo "Go to your browser and check map at the following address"
 echo "http://IP-of-Pi/dump1090/"
 echo "If new map does not show:"
 echo "Clear browser cache (Ctrl+Shift+Delete) and Reload Browser (Ctrl+F5)"


### PR DESCRIPTION
If a user is not using dvb-t as receiver-type setting, the fr24 script
for installing dump1090 does not run.  In this case just install
dump1090-mutability directly.  Removing dump1090-mutability before
installing it should not be necessary and can be a problem if it was
previously configured for beast-tcp.  Also remove sudo for several
commands as the script should run as root anyway.